### PR TITLE
Added documentation link for ExSetTimerResolution

### DIFF
--- a/docs/research.md
+++ b/docs/research.md
@@ -276,6 +276,8 @@ Resolution: 0.500000ms, Sleep(1) slept 1.495500ms (delta: 0.495500)
 Resolution: 0.500000ms, Sleep(1) slept 1.494400ms (delta: 0.494400)
 ```
 
+**See also: [ExSetTimerResolution](https://github.com/MicrosoftDocs/windows-driver-docs-ddi/blob/staging/wdk-ddi-src/content/wdm/nf-wdm-exsettimerresolution.md)**
+
 <h2 id="micro-adjusting-timer-resolution-for-higher-precision">7. Micro-Adjusting Timer Resolution for Higher Precision <a href="#micro-adjusting-timer-resolution-for-higher-precision">(permalink)</a></h2>
 
 Everyone is aware that raising the timer resolution/timer resolution results in higher precision. On most systems, 0.5ms is the maximum supported resolution, but what advantage does micro-adjusting the resolution bring to the table?


### PR DESCRIPTION
Hi there.
I wanted to make you aware of [this function](https://github.com/MicrosoftDocs/windows-driver-docs-ddi/blob/staging/wdk-ddi-src/content/wdm/nf-wdm-exsettimerresolution.md).

The documentation for it has the following description:
`
The ExSetTimerResolution routine modifies the frequency at which the system clock interrupts.
`

[Supposedly it is used](https://forums.blurbusters.com/viewtopic.php?t=9838&start=50#p94961) by the [DPC Latency Checker](https://www.softpedia.com/get/System/System-Info/DPC-Latency-Checker.shtml),
which [makes it possible to force a global timer resolution](https://www.youtube.com/watch?v=vt1n4j9lWF0) even on Windows 10, Version 2004 and newer.

Maybe you could debug if this is really working?
(If MeasureSleep is correct, it should be)

And if it is working, maybe you could incorporate it into SetTimerResolution for Windows 10 users?